### PR TITLE
Fix header menu margin problem

### DIFF
--- a/src/components/header/index.scss
+++ b/src/components/header/index.scss
@@ -35,7 +35,6 @@
         display: none;
         width: 19px;
         margin-right: 40px;
-        margin-top: $headerHeight / 2 - 15px;
         cursor: pointer;
       }
     }

--- a/src/components/header/index.scss
+++ b/src/components/header/index.scss
@@ -35,6 +35,7 @@
         display: none;
         width: 19px;
         margin-right: 40px;
+        margin-top: $headerHeight / 2 - 37px;
         cursor: pointer;
       }
     }


### PR DESCRIPTION
将窄屏顶部的菜单按钮向上移动了一些

修改前：

![image](https://user-images.githubusercontent.com/4352234/73755886-b93ee600-4734-11ea-933a-6c8f3c316c6c.png)

修改后：

![image](https://user-images.githubusercontent.com/4352234/73755922-c78d0200-4734-11ea-99a2-d31a9fae3b6d.png)

fixed #66 
