### PR TITLE
Fixed a link issue

### DIFF
--- a/site_config/project.js
+++ b/site_config/project.js
@@ -50,7 +50,7 @@ export default {
                     img: '/images/blog/wuhan2020.png',
                     title: '新型冠状病毒防疫信息收集平台',
                     description: '社区研发的一个信息系统。方便资源提供者(医疗资源捐献者、物流公司、酒店、义诊资源)和需要帮助者（医院、灾区群众）之间信息互通，以方便快速地使灾区人民得到救助。',
-                    link: 'https://wh.opensource-service.cn/',
+                    link: 'https://wuhan2020.kaiyuanshe.cn/',
                 },
                 {
                     img: '/images/blog/wuhan2020.png',


### PR DESCRIPTION
第一个项目和第二个项目链接重复了。把第一个项目的链接修改为 https://wuhan2020.kaiyuanshe.cn/