### PR TITLE
Google Translate Button

### DIFF
--- a/src/components/footer/index.jsx
+++ b/src/components/footer/index.jsx
@@ -28,6 +28,7 @@ class Footer extends React.Component {
         <div className="footer-body">
           <img src={getLink(logo)} />
           <p className="docsite-power">website powered by docsite</p>
+          {language=='en-us' ? (<div id="google_translate_element"></div>) : null}
           <div className="cols-container">
             <div className="col col-6">
               <h3>{dataSource.vision.title}</h3>

--- a/src/components/footer/index.jsx
+++ b/src/components/footer/index.jsx
@@ -28,7 +28,7 @@ class Footer extends React.Component {
         <div className="footer-body">
           <img src={getLink(logo)} />
           <p className="docsite-power">website powered by docsite</p>
-          {language=='en-us' ? (<div id="google_translate_element"></div>) : null}
+          <div id="google_translate_element"></div>
           <div className="cols-container">
             <div className="col col-6">
               <h3>{dataSource.vision.title}</h3>

--- a/src/components/footer/index.scss
+++ b/src/components/footer/index.scss
@@ -92,6 +92,7 @@
       }
     }
     #google_translate_element {
+      margin-bottom: 40px;
       img {
         height: 14px;
         margin-right: 0;

--- a/src/components/footer/index.scss
+++ b/src/components/footer/index.scss
@@ -89,7 +89,13 @@
       span {
         display: inline-block;
         margin: 0 auto;
-      } 
+      }
+    }
+    #google_translate_element {
+      img {
+        height: 14px;
+        margin-right: 0;
+      }
     }
   }
 }

--- a/template.ejs
+++ b/template.ejs
@@ -21,15 +21,22 @@
 
   </script>
   <script src="<%= rootPath %>/build/<%= page %>.js"></script>
-  
+
 <script>
 var _hmt = _hmt || [];
 (function() {
   var hm = document.createElement("script");
   hm.src = "https://hm.baidu.com/hm.js?b6e4b6fa9a64719756faaf4e9b314bb7";
-  var s = document.getElementsByTagName("script")[0]; 
+  var s = document.getElementsByTagName("script")[0];
   s.parentNode.insertBefore(hm, s);
 })();
+</script>
+
+<script type="text/javascript" src="https://translate.google.cn/translate_a/element.js?cb=googleTranslateElementInit"></script>
+<script type="text/javascript">
+  function googleTranslateElementInit() {
+    new google.translate.TranslateElement({pageLanguage: 'en'}, 'google_translate_element');
+  }
 </script>
 
 </body>

--- a/template.ejs
+++ b/template.ejs
@@ -35,7 +35,7 @@ var _hmt = _hmt || [];
 <script type="text/javascript" src="https://translate.google.cn/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <script type="text/javascript">
   function googleTranslateElementInit() {
-    new google.translate.TranslateElement({pageLanguage: 'en'}, 'google_translate_element');
+    new google.translate.TranslateElement({}, 'google_translate_element');
   }
 </script>
 


### PR DESCRIPTION
添加了谷歌翻译的按钮到页面底部。

![image](https://user-images.githubusercontent.com/4352234/74114263-0973d900-4b77-11ea-855c-c02fafce790a.png)

![image](https://user-images.githubusercontent.com/4352234/74114273-24464d80-4b77-11ea-8f62-e70bd67e3205.png)

这个按钮的代码是来自 google.cn，所以国内的小伙伴应该也能打开。

一个已知的问题是用户点了翻译以后页面顶部会出现一个翻译条，正好遮住了我们的导航栏。目前暂时没有好的解决办法（用 CSS/JavaScript 去掉会产生一连串新问题）。

另一个问题是谷歌在2019宣布弃用这个工具，但没有给出下线时间，未来某一天可能会突然失效。