### PR TITLE
Revert "fix: developers menu item highlighting issue, fix#439"

### DIFF
--- a/src/pages/documentation/index.jsx
+++ b/src/pages/documentation/index.jsx
@@ -24,20 +24,16 @@ class Documentation extends Language {
     super(props);
     this.state = {
       __html: '',
-      currentKey: 'docs'
     };
   }
 
   componentDidMount() {
-    const pathname = window.location.pathname;
-    const isDevelop = pathname.split('/').pop().lastIndexOf('_dev.html') !== -1;
     // 通过请求获取生成好的json数据，静态页和json文件在同一个目录下
-    fetch(pathname.replace(/\.html$/i, '.json'))
+    fetch(window.location.pathname.replace(/\.html$/i, '.json'))
     .then(res => res.json())
     .then((md) => {
       this.setState({
         __html: md && md.__html ? md.__html : '',
-        currentKey: isDevelop ? 'developers': 'docs',
       });
     });
     this.markdownContainer.addEventListener('click', (e) => {
@@ -93,16 +89,15 @@ class Documentation extends Language {
 
   render() {
     const language = this.getLanguage();
-    const { currentKey } = this.state; 
     // 开发者页借助文档页载体
-    const currentPage = currentKey === 'docs' ? 'docs' : 'develop';
-    const dataSource = this.getLanguageDict(language, currentPage);
+    const isDevelop = window.location.pathname.split('/').pop().lastIndexOf('_dev.html') !== -1;
+    const dataSource = isDevelop ? this.getLanguageDict(language, 'develop') : this.getLanguageDict(language, 'docs');
     // const dataSource = isDevelop ? (developConfig[language] || developConfig[siteConfig.defaultLanguage]) : (docsConfig[language] || docsConfig[siteConfig.defaultLanguage]);
     const __html = this.props.__html || this.state.__html;
     return (
       <div className="documentation-page">
         <Header
-            currentKey={currentKey}
+            currentKey={isDevelop ? 'developers' : 'docs'}
             type="normal"
             logo="/images/wuhan2020-logo.png"
             language={language}


### PR DESCRIPTION
Reverts wuhan2020/wuhan2020.github.io#457



(node:2776) UnhandledPromiseRejectionWarning: SecurityError: localStorage is not available for opaque origins
    at Window.localStorage (/home/runner/work/wuhan2020.github.io/wuhan2020.github.io/node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
    at new GitalkComponent (/home/runner/work/wuhan2020.github.io/wuhan2020.github.io/node_modules/gitalk/dist/webpack:/gitalk.jsx:84:34)
    at processChild (/home/runner/work/wuhan2020.github.io/wuhan2020.github.io/node_modules/react-dom/cjs/react-dom-server.node.development.js:2995:14)
    at resolve (/home/runner/work/wuhan2020.github.io/wuhan2020.github.io/node_modules/react-dom/cjs/react-dom-server.node.development.js:2960:5)
    at ReactDOMServerRenderer.render (/home/runner/work/wuhan2020.github.io/wuhan2020.github.io/node_modules/react-dom/cjs/react-dom-server.node.development.js:3435:22)
    at ReactDOMServerRenderer.read (/home/runner/work/wuhan2020.github.io/wuhan2020.github.io/node_modules/react-dom/cjs/react-dom-server.node.development.js:3373:29)
    at Object.renderToString (/home/runner/work/wuhan2020.github.io/wuhan2020.github.io/node_modules/react-dom/cjs/react-dom-server.node.development.js:3988:27)
    at files.forEach.file (/home/runner/work/wuhan2020.github.io/wuhan2020.github.io/node_modules/docsite/lib/generateJSONFile.js:87:38)
    at Array.forEach (<anonymous>)
    at parse (/home/runner/work/wuhan2020.github.io/wuhan2020.github.io/node_modules/docsite/lib/generateJSONFile.js:39:11)
(node:2776) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:2776) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
/home/runner/work/wuhan2020.github.io/wuhan2020.github.io/sitemap-generator.js:19
    items.forEach(function (item) {
          ^

TypeError: Cannot read property 'forEach' of undefined
    at /home/runner/work/wuhan2020.github.io/wuhan2020.github.io/sitemap-generator.js:19:11
    at FSReqWrap.args [as oncomplete] (fs.js:140:20)
##[error]Process completed with exit code 1.