### PR TITLE
change build instrution

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Please also make sure your node version is higher than 8.x.
 
 ## Build instruction
 
-1. Run ` npm i docsite@wuhan2020 -g ` to install docsite for project wuhan2020.
+1. Run `npm i docsite@wuhan2020 -g ` to install docsite for project wuhan2020.
 2. Run `npm i` in the root directory to install the dependencies.
-3. Run `docsite start` in the root directory to start a local server, you will see the website in 'http://127.0.0.1:8080'.
-4. Run `docsite build` to build source code.
+3. Run `npm run start` in the root directory to start a local server, you will see the website in 'http://127.0.0.1:8080'.
+4. Run `npm run build` to build source code.
 5. Verify your change locally: `python -m SimpleHTTPServer 8000`, when your python version is 3 use :`python3 -m http.server 8000` instead.
 
 If you have higher version of node installed, you may consider `nvm` to allow different versions of `node` coexisting on your machine.


### PR DESCRIPTION
When running `docsite start` and `docsite build`, it occurs:

`(node:15792) UnhandledPromiseRejectionWarning: Error: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:`
`1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.
    at resolveDispatcher (C:\work\wuhan2020.github.io\node_modules\_react@16.13.1@react\cjs\react.development.js:1465:13)
    at useState (C:\work\wuhan2020.github.io\node_modules\_react@16.13.1@react\cjs\react.development.js:1496:20)
    at TeamItem (C:\work\wuhan2020.github.io\src\pages\hackathonKanban/teamItem.jsx:14:51)
    at processChild (C:\Users\inter\AppData\Roaming\nvm\v10.19.0\node_modules\docsite\node_modules\_react-dom@16.13.1@react-dom\cjs\react-dom-server.node.development.js:3043:14)
    at resolve (C:\Users\inter\AppData\Roaming\nvm\v10.19.0\node_modules\docsite\node_modules\_react-dom@16.13.1@react-dom\cjs\react-dom-server.node.development.js:2960:5)
    at ReactDOMServerRenderer.render (C:\Users\inter\AppData\Roaming\nvm\v10.19.0\node_modules\docsite\node_modules\_react-dom@16.13.1@react-dom\cjs\react-dom-server.node.development.js:3435:22)
    at ReactDOMServerRenderer.read (C:\Users\inter\AppData\Roaming\nvm\v10.19.0\node_modules\docsite\node_modules\_react-dom@16.13.1@react-dom\cjs\react-dom-server.node.development.js:3373:29)
    at Object.renderToString (C:\Users\inter\AppData\Roaming\nvm\v10.19.0\node_modules\docsite\node_modules\_react-dom@16.13.1@react-dom\cjs\react-dom-server.node.development.js:3988:27)
    at langs.forEach.lang (C:\Users\inter\AppData\Roaming\nvm\v10.19.0\node_modules\docsite\lib\generateHTMLFile.js:118:36)
    at Array.forEach (<anonymous>)
(node:15792) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:15792) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.`

There is no error when using `npm run start` and `npm run build`.