### PR TITLE
Move Gitalk Code to A Component

### DIFF
--- a/src/components/gitalk/index.jsx
+++ b/src/components/gitalk/index.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './index.scss';
+import GitalkComponent from "gitalk/dist/gitalk-component";
+import 'gitalk/dist/gitalk.css';
+
+const propTypes = {
+  class_name: PropTypes.string.isRequired
+};
+
+class Gitalk extends React.Component {
+  render() {
+    const { class_name } = this.props;
+
+    return(
+      <section className={class_name}>
+        <GitalkComponent options={{
+          clientID: "728da77f67226e477f03",
+          clientSecret: 'ec7e55e9a7a022900677599b776e4164c1fdd759',
+          repo: 'website-comment',
+          owner: 'wuhan2020',
+          admin: ['zhaofeng-shu33', 'iLtc', 'jeremy0519', 'lovepoem', 'chenrui333'],
+          id: window.location.pathname,
+          distractionFreeMode: false // Facebook-like distraction free mode
+        }}/>
+      </section>
+    )
+  }
+}
+
+Gitalk.propTypes = propTypes;
+
+export default Gitalk;

--- a/src/components/gitalk/index.scss
+++ b/src/components/gitalk/index.scss
@@ -1,0 +1,1 @@
+@import '../../variables.scss';

--- a/src/pages/blog/index.jsx
+++ b/src/pages/blog/index.jsx
@@ -9,9 +9,8 @@ import Footer from '../../components/footer';
 import siteConfig from '../../../site_config/site';
 import { getLink } from '../../../utils';
 import mdJson from '../../../md_json/blog.json';
+import Gitalk from '../../components/gitalk'
 import './index.scss';
-import GitalkComponent from "gitalk/dist/gitalk-component";
-import 'gitalk/dist/gitalk.css';
 const {
   langList = [
       { value: 'zh-cn', text: '简体中文' },
@@ -70,17 +69,7 @@ class Blog extends Language {
             </ul>
           </div>
         </section>
-        <section className="blog-container">
-          <GitalkComponent options={{
-            clientID: "728da77f67226e477f03",
-            clientSecret: 'ec7e55e9a7a022900677599b776e4164c1fdd759',
-            repo: 'website-comment',
-            owner: 'wuhan2020',
-            admin: ['zhaofeng-shu33', 'iLtc', 'jeremy0519', 'lovepoem', 'chenrui333'],
-            id: window.location.pathname,
-            distractionFreeMode: false // Facebook-like distraction free mode
-          }}/>
-        </section>
+        <Gitalk class_name="blog-container"/>
         <Footer logo="/images/wuhan2020-logo-gray.png" language={language} />
       </div>
     );

--- a/src/pages/blogDetail/index.jsx
+++ b/src/pages/blogDetail/index.jsx
@@ -7,8 +7,7 @@ import Language from '../../components/language';
 import Header from '../../components/header';
 import Footer from '../../components/footer';
 import './index.scss';
-import GitalkComponent from "gitalk/dist/gitalk-component";
-import 'gitalk/dist/gitalk.css';
+import Gitalk from '../../components/gitalk';
 
 // 锚点正则
 const anchorReg = /^#[^/]/;
@@ -110,17 +109,7 @@ class BlogDetail extends Language {
           ref={(node) => { this.markdownContainer = node; }}
           dangerouslySetInnerHTML={{ __html }}
         />
-        <section className="blog-container">
-          <GitalkComponent options={{
-            clientID: "728da77f67226e477f03",
-            clientSecret: 'ec7e55e9a7a022900677599b776e4164c1fdd759',
-            repo: 'website-comment',
-            owner: 'wuhan2020',
-            admin: ['zhaofeng-shu33', 'iLtc', 'jeremy0519', 'lovepoem', 'chenrui333'],
-            id: window.location.pathname,
-            distractionFreeMode: false // Facebook-like distraction free mode
-          }}/>
-        </section>
+        <Gitalk class_name="blog-content"/>
         <Footer logo="/images/wuhan2020-logo-gray.png" language={language} />
       </div>
     );

--- a/src/pages/community/index.jsx
+++ b/src/pages/community/index.jsx
@@ -8,10 +8,9 @@ import EventCard from './eventCard';
 import ContactItem from './contactItem';
 import ContributorItem from './contributorItem';
 import Footer from '../../components/footer';
-
+import Gitalk from '../../components/gitalk';
 import './index.scss';
-import GitalkComponent from "gitalk/dist/gitalk-component";
-import 'gitalk/dist/gitalk.css';
+
 class Community extends Language {
 
   render() {
@@ -58,17 +57,7 @@ class Community extends Language {
           }
           </div>
         </section>
-        <section className="contributor-section">
-          <GitalkComponent options={{
-            clientID: "728da77f67226e477f03",
-            clientSecret: 'ec7e55e9a7a022900677599b776e4164c1fdd759',
-            repo: 'website-comment',
-            owner: 'wuhan2020',
-            admin: ['zhaofeng-shu33', 'iLtc', 'jeremy0519', 'lovepoem', 'chenrui333'],
-            id: window.location.pathname,
-            distractionFreeMode: false // Facebook-like distraction free mode
-          }}/>
-        </section>
+        <Gitalk class_name="contributor-section"/>
         <Footer logo="/images/wuhan2020-logo-gray.png" language={language} />
       </div>
     );

--- a/src/pages/documentation/index.jsx
+++ b/src/pages/documentation/index.jsx
@@ -8,9 +8,8 @@ import Header from '../../components/header';
 import Bar from '../../components/bar';
 import Sidemenu from '../../components/sidemenu';
 import Footer from '../../components/footer';
+import Gitalk from '../../components/gitalk';
 import './index.scss';
-import GitalkComponent from "gitalk/dist/gitalk-component";
-import 'gitalk/dist/gitalk.css';
 
 // 锚点正则
 const anchorReg = /^#[^/]/;
@@ -116,17 +115,7 @@ class Documentation extends Language {
             dangerouslySetInnerHTML={{ __html }}
           />
         </section>
-        <section className="content-section">
-          <GitalkComponent options={{
-            clientID: "728da77f67226e477f03",
-            clientSecret: 'ec7e55e9a7a022900677599b776e4164c1fdd759',
-            repo: 'website-comment',
-            owner: 'wuhan2020',
-            admin: ['zhaofeng-shu33', 'iLtc', 'jeremy0519', 'lovepoem', 'chenrui333'],
-            id: window.location.pathname,
-            distractionFreeMode: false // Facebook-like distraction free mode
-          }}/>
-        </section>
+        <Gitalk class_name="content-section"/>
         <Footer logo="/images/wuhan2020-logo-gray.png" language={language} />
       </div>
     );

--- a/src/pages/documentation/index.scss
+++ b/src/pages/documentation/index.scss
@@ -9,7 +9,6 @@
     box-sizing: border-box;
     padding: 40px 40px 60px;
     position: relative;
-    min-height: 1100px;
     .doc-content {
       display: inline-block;
       vertical-align: top;

--- a/src/pages/hackathon/index.jsx
+++ b/src/pages/hackathon/index.jsx
@@ -6,10 +6,8 @@ import Footer from '../../components/footer';
 import Language from '../../components/language';
 // import HackathonItem from './hackathonItem';
 import {getLink} from '../../../utils';
-
+import Gitalk from '../../components/gitalk';
 import './index.scss';
-import GitalkComponent from "gitalk/dist/gitalk-component";
-import 'gitalk/dist/gitalk.css';
 
 const ActivityProfile = (props) => {
   return (<div className={props.class_name}>
@@ -278,17 +276,7 @@ class Hackathon extends Language {
 
         </section>
 
-        <section className="hackathon-section">
-          <GitalkComponent options={{
-            clientID: "728da77f67226e477f03",
-            clientSecret: 'ec7e55e9a7a022900677599b776e4164c1fdd759',
-            repo: 'website-comment',
-            owner: 'wuhan2020',
-            admin: ['zhaofeng-shu33', 'iLtc', 'jeremy0519', 'lovepoem', 'chenrui333'],
-            id: window.location.pathname,
-            distractionFreeMode: false // Facebook-like distraction free mode
-          }}/>
-        </section>
+        <Gitalk class_name="hackathon-section"/>
         <Footer logo="/images/wuhan2020-logo-gray.png" language={language}/>
       </div>
     );

--- a/src/pages/hackathonKanban/index.jsx
+++ b/src/pages/hackathonKanban/index.jsx
@@ -86,7 +86,7 @@ class HackathonKanban extends Language {
                         </section>
                     </article>
                 </main>
-                <Gitalk class_name=""/>
+                <Gitalk class_name="kanban-page"/>
                 <Footer logo="/images/wuhan2020-logo-gray.png" language={language} />
             </div>
         );

--- a/src/pages/hackathonKanban/index.jsx
+++ b/src/pages/hackathonKanban/index.jsx
@@ -8,9 +8,8 @@ import Footer from '../../components/footer';
 import CountryMapList from './countryMapItem';
 import TeamItemList from './teamItemList';
 import HackathonProgress from './hackathonProgress';
+import Gitalk from '../../components/gitalk';
 import './index.scss';
-import GitalkComponent from "gitalk/dist/gitalk-component";
-import 'gitalk/dist/gitalk.css';
 
 const mockMilestones = [{
     time: '02-28',
@@ -87,17 +86,7 @@ class HackathonKanban extends Language {
                         </section>
                     </article>
                 </main>
-                <section className="kanban-page">
-                  <GitalkComponent options={{
-                    clientID: "728da77f67226e477f03",
-                    clientSecret: 'ec7e55e9a7a022900677599b776e4164c1fdd759',
-                    repo: 'website-comment',
-                    owner: 'wuhan2020',
-                    admin: ['zhaofeng-shu33', 'iLtc', 'jeremy0519', 'lovepoem', 'chenrui333'],
-                    id: window.location.pathname,
-                    distractionFreeMode: false // Facebook-like distraction free mode
-                  }}/>
-                </section>
+                <Gitalk class_name=""/>
                 <Footer logo="/images/wuhan2020-logo-gray.png" language={language} />
             </div>
         );

--- a/src/pages/project/index.jsx
+++ b/src/pages/project/index.jsx
@@ -5,9 +5,8 @@ import Bar from '../../components/bar';
 import Footer from '../../components/footer';
 import Language from '../../components/language';
 import ProjectItem from './projectItem';
+import Gitalk from '../../components/gitalk';
 import './index.scss';
-import GitalkComponent from "gitalk/dist/gitalk-component";
-import 'gitalk/dist/gitalk.css';
 class Project extends Language {
     render() {
         const language = this.getLanguage();
@@ -29,17 +28,7 @@ class Project extends Language {
                     <ProjectItem project={project} key={i} />
                     ))}
                 </section>
-                <section className="project-section">
-                  <GitalkComponent options={{
-                    clientID: "728da77f67226e477f03",
-                    clientSecret: 'ec7e55e9a7a022900677599b776e4164c1fdd759',
-                    repo: 'website-comment',
-                    owner: 'wuhan2020',
-                    admin: ['zhaofeng-shu33', 'iLtc', 'jeremy0519', 'lovepoem', 'chenrui333'],
-                    id: window.location.pathname,
-                    distractionFreeMode: false // Facebook-like distraction free mode
-                  }}/>
-                </section>
+                <Gitalk class_name="project-section"/>
                 <Footer logo="/images/wuhan2020-logo-gray.png" language={language} />
             </div>
         );


### PR DESCRIPTION
There are some conflicts if I move the code to the footer, so I put the code in a separate component file.

I also fixed the while space problem for the documentation page.

![image](https://user-images.githubusercontent.com/4352234/77281223-defc5c00-6c9c-11ea-9e01-6f5e600a84a8.png)

PS: You should be able to preview this change by clicking the Netflix link below.