### PR TITLE
ci: 修复docsite编译失败的问题

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,9 @@ jobs:
         node-version: 10.x
     - name: Build
       run: |
-        npm install
-        npm run build
+        npm install -g yarn
+        yarn
+        yarn build
         node sitemap-generator.js
         mkdir deploy-dist
         cp -R zh-cn/ en-us/ ja-jp/ it-it/ fr-fr/ pt-br/ build/ images/ md_json/ site_config/ lib/ deploy-dist/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ yarn.lock
 md_json/
 log
 sitemap.xml
+deploy-dist

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "docsite start",
-    "build": "docsite build"
+    "build": "docsite build",
+    "postinstall": "node tools/docsite-apply-patch.js"
   },
   "devDependencies": {
     "@babel/core": "^7.6.0",
@@ -38,6 +39,7 @@
     "eslint-plugin-import": "*",
     "eslint-plugin-react": "*",
     "extract-text-webpack-plugin": "^2.1.2",
+    "gitalk": "^1.7.2",
     "gulp": "3.9.1",
     "gulp-util": "2.2.20",
     "json-loader": "*",
@@ -50,23 +52,29 @@
     "react": "~16.13.0",
     "react-dom": "~16.13.0",
     "resolve-url-loader": "^3.1.1",
+    "rimraf": "^3.0.2",
     "sass-loader": "6.0.2",
     "style-loader": "0.6.5",
     "webpack": "^3.1.11",
-    "webpack-dev-server": "^2.4.5",
-    "gitalk": "^1.6.2"
+    "webpack-dev-server": "^2.4.5"
   },
   "dependencies": {
     "antd": "^3.26.7",
     "classnames": "^2.2.5",
     "core-decorators": "^0.20.0",
-    "docsite": "wuhan2020",
+    "docsite": "1.3.11",
     "echarts": "^4.6.0",
     "echarts-for-react": "^2.0.15-beta.1",
     "file-loader": "^3.0.1",
     "js-cookie": "^2.2.0",
+    "jsdom": "11.11.0",
     "react-scroll": "^1.7.9",
     "whatwg-fetch": "^2.0.4",
     "xmlbuilder": "^14.0.0"
+  },
+  "resolutions": {
+    "docsite/react": "16.13.0",
+    "docsite/react-dom": "16.13.0",
+    "docsite/jsdom": "11.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-import": "*",
     "eslint-plugin-react": "*",
     "extract-text-webpack-plugin": "^2.1.2",
-    "gitalk": "^1.7.2",
+    "gitalk": "^1.6.2",
     "gulp": "3.9.1",
     "gulp-util": "2.2.20",
     "json-loader": "*",
@@ -67,7 +67,7 @@
     "echarts-for-react": "^2.0.15-beta.1",
     "file-loader": "^3.0.1",
     "js-cookie": "^2.2.0",
-    "jsdom": "11.11.0",
+    "jsdom": "11.12.0",
     "react-scroll": "^1.7.9",
     "whatwg-fetch": "^2.0.4",
     "xmlbuilder": "^14.0.0"
@@ -75,6 +75,6 @@
   "resolutions": {
     "docsite/react": "16.13.0",
     "docsite/react-dom": "16.13.0",
-    "docsite/jsdom": "11.11.0"
+    "docsite/jsdom": "11.12.0"
   }
 }

--- a/sitemap-generator.js
+++ b/sitemap-generator.js
@@ -14,16 +14,18 @@ languages.forEach(function (lang) {
 
 function ls(path) {
   waitingCount ++;
-
   fs.readdir(path, function(err, items) {
-    items.forEach(function (item) {
-      if (fs.lstatSync(path + "/" + item).isDirectory()) {
-        ls(path + "/" + item)
-      } else {
-        if (!item.endsWith('json'))
-          files.push(domain + path + "/" + item);
-      }
-    });
+    if (items) {
+      items.forEach(function (item) {
+        if (fs.lstatSync(path + "/" + item).isDirectory()) {
+          ls(path + "/" + item)
+        } else {
+          if (!item.endsWith('json'))
+            files.push(domain + path + "/" + item);
+        }
+      });
+    }
+
 
     waitingCount --;
 

--- a/src/pages/blog/index.jsx
+++ b/src/pages/blog/index.jsx
@@ -25,9 +25,11 @@ const langValueList = langList.map(l => l.value);
 // 博客列表数据，按时间排序
 const blogs = {};
 langValueList.forEach((lang) => {
-  blogs[lang] = mdJson[lang].filter(md => (
-    (!md.meta.hidden || md.meta.hidden === 'false') && md.link.indexOf('download.html') === -1 && md.link.indexOf('client.html') === -1
-  )).sort((a, b) => new Date(b.meta.date) - new Date(a.meta.date));
+  if (mdJson[lang]) {
+    blogs[lang] = mdJson[lang].filter(md => (
+      (!md.meta.hidden || md.meta.hidden === 'false') && md.link.indexOf('download.html') === -1 && md.link.indexOf('client.html') === -1
+    )).sort((a, b) => new Date(b.meta.date) - new Date(a.meta.date));
+  }
 });
 
 class Blog extends Language {

--- a/tools/docsite-apply-patch.js
+++ b/tools/docsite-apply-patch.js
@@ -1,0 +1,14 @@
+const path = require('path');
+const rimraf = require('rimraf');
+docsitePath = path.join(__dirname, '..', 'node_modules/docsite/node_modules');
+console.log('remove react in docsite');
+rimraf(path.join(docsitePath, 'react'), (err) => {
+  if (err) {
+    console.log(err)
+  }
+});
+rimraf(path.join(docsitePath, 'react-dom'), (err) => {
+  if (err) {
+    console.log(err)
+  }
+});

--- a/tools/docsite-apply-patch.js
+++ b/tools/docsite-apply-patch.js
@@ -1,4 +1,6 @@
+// 以后在优化吧
 const path = require('path');
+const fs = require('fs');
 const rimraf = require('rimraf');
 docsitePath = path.join(__dirname, '..', 'node_modules/docsite/node_modules');
 console.log('remove react in docsite');
@@ -12,3 +14,15 @@ rimraf(path.join(docsitePath, 'react-dom'), (err) => {
     console.log(err)
   }
 });
+fs.unlinkSync(path.join(__dirname, '..', 'node_modules/docsite/lib/build.js'));
+fs.unlinkSync(path.join(__dirname, '..', 'node_modules/docsite/lib/generateHTMLFile.js'));
+fs.unlinkSync(path.join(__dirname, '..', 'node_modules/docsite/lib/generateJSONFile.js'));
+
+function copyFile(src, dist) {
+  fs.writeFileSync(dist, fs.readFileSync(src));
+}
+
+copyFile(path.join(__dirname, 'docsite/build.js'), path.join(__dirname, '..', 'node_modules/docsite/lib/build.js'));
+copyFile(path.join(__dirname, 'docsite/start.js'), path.join(__dirname, '..', 'node_modules/docsite/lib/start.js'));
+copyFile(path.join(__dirname, 'docsite/generateHTMLFile.js'), path.join(__dirname, '..', 'node_modules/docsite/lib/generateHTMLFile.js'));
+copyFile(path.join(__dirname, 'docsite/generateJSONFile.js'), path.join(__dirname, '..', 'node_modules/docsite/lib/generateJSONFile.js'));

--- a/tools/docsite/build.js
+++ b/tools/docsite/build.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const shell = require('shelljs');
+const path = require('path');
+const generateJSONFile = require('./generateJSONFile.js');
+const generateHTMLFile = require('./generateHTMLFile.js');
+
+const CWD = process.cwd();
+
+const build = () => {
+  try {
+    shell.cd(CWD);
+
+    // mock brower
+    const jsdom = require('jsdom');
+    const { JSDOM } = jsdom;
+    // this is old code
+    // const dom = new JSDOM(
+    //   '<!doctype html><html><body><head><link/><style></style><script></script></head><script></script></body></html>'
+    // );
+    // this is new code
+    const dom = new JSDOM(`<!doctype html><html><body><head><link/><style></style><script></script></head><script></script></body></html>`, {
+      url: "http://localhost"
+    });
+    const { window } = dom;
+    const copyProps = (src, target) => {
+      const props = Object.getOwnPropertyNames(src)
+        .filter(prop => typeof target[prop] === 'undefined')
+        .map(prop => Object.getOwnPropertyDescriptor(src, prop));
+      Object.defineProperties(target, props);
+    };
+    window.requestAnimationFrame = (window.requestAnimationFrame) || (f => window.setTimeout(f, 1e3 / 60));
+    window.matchMedia = window.matchMedia || function() {
+      return {
+        matches: false,
+        addListener() {},
+        removeListener() {},
+      };
+    };
+    global.window = window;
+    global.document = window.document;
+    global.HTMLElement = window.HTMLElement;
+    global.navigator = {
+      userAgent: 'node.js',
+    };
+    copyProps(window, global);
+    generateJSONFile('prod', CWD);
+    generateHTMLFile('prod', CWD);
+    const platform = process.platform;
+    if (platform === 'win32') {
+      shell.exec(`node ${['node_modules', 'gulp', 'bin', 'gulp.js'].join(path.sep)} build`);
+    } else {
+      shell.exec(`${['node_modules', 'gulp', 'bin', 'gulp.js'].join(path.sep)} build`);
+    }
+  } catch(e) {
+    console.error(e)
+  }
+};
+
+module.exports = build;

--- a/tools/docsite/generateHTMLFile.js
+++ b/tools/docsite/generateHTMLFile.js
@@ -1,0 +1,164 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs-extra');
+const React = require('react');
+const ReactDOMServer = require('react-dom/server');
+const chalk = require('chalk');
+const ejs = require('ejs');
+const yaml = require('js-yaml');
+
+let siteConfig;
+try {
+  // 初始化时该文件还不存在
+  siteConfig = require(path.join(process.cwd(), './site_config/site')).default;
+} catch (err) {
+  // do nothing
+}
+let docsiteConfig;
+
+try {
+  const configPath = path.join(process.cwd(), 'docsite.config.yml');
+  if (fs.existsSync(configPath)) {
+    docsiteConfig = yaml.safeLoad(fs.readFileSync(configPath, 'utf8'));
+  }
+} catch (err) {
+  console.log(err);
+}
+
+const getConfigValue = (config, type, page, language, key) => {
+  try {
+    return config[type][page][language][key];
+  } catch (err) {
+    return '';
+  }
+};
+const generateHTMLFile = (env, cwd) => {
+  if (env === 'dev') {
+    window.rootPath = '';
+  } else if (env === 'prod') {
+    window.rootPath = siteConfig.rootPath;
+  }
+  // 生成404.html、重定向页面（用于初始进入的语言跳转）
+  if (fs.existsSync(path.join(cwd, './redirect.ejs'))) {
+    ejs.renderFile(
+      path.join(cwd, './redirect.ejs'),
+      {
+        defaultLanguage: siteConfig.defaultLanguage,
+        rootPath: window.rootPath,
+      },
+      (err, str) => {
+        if (err) {
+          console.log(chalk.red(err));
+          process.exit(1);
+        }
+        fs.writeFileSync(path.join(cwd, '404.html'), str, 'utf8');
+        fs.writeFileSync(path.join(cwd, 'index.html'), str, 'utf8');
+      }
+    );
+  }
+  // 生成首页（home），直接放置在语言目录下
+  if (fs.existsSync(path.join(cwd, './src/pages', 'home', './index.jsx'))) {
+    // 导入用ES6 export default导出的模块
+    const Page = require(path.join(cwd, './src/pages', 'home')).default;
+    // 生成英文版
+    fs.ensureDirSync(path.join(cwd, 'en-us'));
+    ejs.renderFile(
+      path.join(cwd, './template.ejs'),
+      {
+        env: env || 'prod',
+        title: getConfigValue(docsiteConfig, 'pages', 'home', 'en-us', 'title') || 'home',
+        keywords: getConfigValue(docsiteConfig, 'pages', 'home', 'en-us', 'keywords') || 'home',
+        description: getConfigValue(docsiteConfig, 'pages', 'home', 'en-us', 'description') || 'home',
+        rootPath: window.rootPath,
+        page: 'home',
+        __html: ReactDOMServer.renderToString(React.createElement(Page, { lang: 'en-us' }, null)),
+      },
+      (err, str) => {
+        if (err) {
+          console.log(chalk.red(err));
+          process.exit(1);
+        }
+        fs.writeFileSync(path.join(cwd, 'en-us', 'index.html'), str, 'utf8');
+      }
+    );
+
+    // 生成中文版
+    fs.ensureDirSync(path.join(cwd, 'zh-cn'));
+    ejs.renderFile(
+      path.join(cwd, './template.ejs'),
+      {
+        env: env || 'prod',
+        title: getConfigValue(docsiteConfig, 'pages', 'home', 'zh-cn', 'title') || 'home',
+        keywords: getConfigValue(docsiteConfig, 'pages', 'home', 'zh-cn', 'keywords') || 'home',
+        description: getConfigValue(docsiteConfig, 'pages', 'home', 'zh-cn', 'description') || 'home',
+        rootPath: window.rootPath,
+        page: 'home',
+        __html: ReactDOMServer.renderToString(React.createElement(Page, { lang: 'zh-cn' }, null)),
+      },
+      (err, str) => {
+        if (err) {
+          console.log(chalk.red(err));
+          process.exit(1);
+        }
+        fs.writeFileSync(path.join(cwd, 'zh-cn', 'index.html'), str, 'utf8');
+      }
+    );
+  }
+  // 生成除博客详情页（blogDetail）、文档页（documentation）首页（home）的其它页面
+  const pages = fs.readdirSync(path.join(cwd, './src/pages'));
+  pages.forEach(page => {
+    if (page === 'blogDetail' || page === 'documentation' || page === 'home') {
+      return;
+    }
+    // 是文件夹并且下面有index.jsx文件
+    if (fs.existsSync(path.join(cwd, './src/pages', page, './index.jsx'))) {
+      // 导入用ES6 export default导出的模块
+      const Page = require(path.join(cwd, './src/pages', page)).default;
+      // 生成英文版
+      fs.ensureDirSync(path.join(cwd, 'en-us', page));
+      ejs.renderFile(
+        path.join(cwd, './template.ejs'),
+        {
+          env: env || 'prod',
+          title: getConfigValue(docsiteConfig, 'pages', page, 'en-us', 'title') || page,
+          keywords: getConfigValue(docsiteConfig, 'pages', page, 'en-us', 'keywords') || page,
+          description: getConfigValue(docsiteConfig, 'pages', page, 'en-us', 'description') || page,
+          rootPath: window.rootPath,
+          page,
+          __html: ReactDOMServer.renderToString(React.createElement(Page, { lang: 'en-us' }, null)),
+        },
+        (err, str) => {
+          if (err) {
+            console.log(chalk.red(err));
+            process.exit(1);
+          }
+          fs.writeFileSync(path.join(cwd, 'en-us', page, 'index.html'), str, 'utf8');
+        }
+      );
+
+      // 生成中文版
+      fs.ensureDirSync(path.join(cwd, 'zh-cn', page));
+      ejs.renderFile(
+        path.join(cwd, './template.ejs'),
+        {
+          env: env || 'prod',
+          title: getConfigValue(docsiteConfig, 'pages', page, 'zh-cn', 'title') || page,
+          keywords: getConfigValue(docsiteConfig, 'pages', page, 'zh-cn', 'keywords') || page,
+          description: getConfigValue(docsiteConfig, 'pages', page, 'zh-cn', 'description') || page,
+          rootPath: window.rootPath,
+          page,
+          __html: ReactDOMServer.renderToString(React.createElement(Page, { lang: 'zh-cn' }, null)),
+        },
+        (err, str) => {
+          if (err) {
+            console.log(chalk.red(err));
+            process.exit(1);
+          }
+          fs.writeFileSync(path.join(cwd, 'zh-cn', page, 'index.html'), str, 'utf8');
+        }
+      );
+    }
+  });
+};
+module.exports = generateHTMLFile;

--- a/tools/docsite/generateJSONFile.js
+++ b/tools/docsite/generateJSONFile.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const path = require('path');
+const React = require('react');
+const ReactDOMServer = require('react-dom/server');
+const chalk = require('chalk');
+const ejs = require('ejs');
+const fs = require('fs-extra');
+const parseMd = require('./parseMd.js');
+
+let siteConfig;
+try {
+  // 初始化时该文件还不存在
+  siteConfig = require(path.join(process.cwd(), './site_config/site')).default;
+} catch (err) {
+  // do noting
+}
+
+const generate = (env, cwd, type, lang, mdData) => {
+  if (env === 'dev') {
+    window.rootPath = '';
+  } else if (env === 'prod') {
+    window.rootPath = siteConfig.rootPath;
+  }
+  const parse = dir => {
+    const files = fs.readdirSync(dir);
+    files.forEach(file => {
+      const filepath = path.join(dir, file);
+      const stat = fs.statSync(filepath);
+      const extension = path.extname(file);
+      if (stat.isFile() && (extension === '.md' || extension === '.markdown')) {
+        const result = parseMd(filepath);
+        // cwd/docs/zh-cn/hello.md => cwd/zh-cn/docs/hello.json
+        const fileInfo = path.parse(filepath);
+        const splitArr = fileInfo.dir.split(`${type}${path.sep}${lang}`);
+        const targetPath = `${splitArr[0]}${lang}${path.sep}${type}${splitArr[1]}`;
+        fs.ensureDirSync(targetPath);
+        fs.writeFileSync(
+          path.join(targetPath, `${fileInfo.name}.json`),
+          JSON.stringify(
+            {
+              filename: file,
+              __html: result.__html,
+              link: path.join(targetPath.replace(`${cwd}`, ''), `${fileInfo.name}.html`), // 对应实际的html链接，未加前缀
+              meta: result.meta,
+            },
+            null,
+            2
+          ),
+          'utf8'
+        );
+        mdData[lang].push(
+          {
+            filename: file,
+            link: path.join(targetPath.replace(`${cwd}`, ''), `${fileInfo.name}.html`), // 对应实际的html链接，未加前缀
+            meta: result.meta,
+          }
+        );
+        // 同步生成HTML，避免再遍历一遍目录
+        // 生成文档
+        if (
+          type === 'docs' &&
+          fs.existsSync(path.join(cwd, './src/pages/documentation'))
+        ) {
+          const Documentation = require(path.join(cwd, './src/pages/documentation'))
+            .default;
+          ejs.renderFile(
+            path.join(cwd, './template.ejs'),
+            {
+              env: env || 'prod',
+              title: result.meta.title || fileInfo.name,
+              keywords: result.meta.keywords || fileInfo.name,
+              description: result.meta.description || fileInfo.name,
+              rootPath: window.rootPath,
+              page: 'documentation',
+              __html: ReactDOMServer.renderToString(
+                React.createElement(Documentation, { lang, __html: result.__html, meta: result.meta }, null)
+              ),
+            },
+            (err, str) => {
+              if (err) {
+                console.log(chalk.red(err));
+                process.exit(1);
+              }
+              fs.writeFileSync(path.join(targetPath, `${fileInfo.name}.html`), str, 'utf8');
+            }
+          );
+        } else if (
+          type === 'blog' &&
+          fs.existsSync(path.join(cwd, './src/pages/blogDetail'))
+        ) {
+          const BlogDetail = require(path.join(cwd, './src/pages/blogDetail')).default;
+          ejs.renderFile(
+            path.join(cwd, './template.ejs'),
+            {
+              env: env || 'prod',
+              title: result.meta.title || fileInfo.name,
+              keywords: result.meta.keywords || fileInfo.name,
+              description: result.meta.description || fileInfo.name,
+              rootPath: window.rootPath,
+              page: 'blogDetail',
+              __html: ReactDOMServer.renderToString(
+                React.createElement(BlogDetail, { lang, __html: result.__html, meta: result.meta }, null)
+              ),
+            },
+            (err, str) => {
+              if (err) {
+                console.log(chalk.red(err));
+                process.exit(1);
+              }
+              fs.writeFileSync(path.join(targetPath, `${fileInfo.name}.html`), str, 'utf8');
+            }
+          );
+        }
+      } else if (stat.isDirectory()) {
+        parse(filepath);
+      }
+    });
+  };
+  parse(path.join(cwd, type, lang));
+};
+const generateJSONFile = (env, cwd) => {
+  const blogData = {
+    'en-us': [],
+    'zh-cn': [],
+  };
+  const docsData = {
+    'en-us': [],
+    'zh-cn': [],
+  };
+  generate(env, cwd, 'docs', 'zh-cn', docsData);
+  generate(env, cwd, 'docs', 'en-us', docsData);
+  generate(env, cwd, 'blog', 'zh-cn', blogData);
+  generate(env, cwd, 'blog', 'en-us', blogData);
+  const mdDataPath = path.join(cwd, 'md_json');
+  fs.ensureDirSync(mdDataPath);
+  fs.writeFileSync(
+    path.join(mdDataPath, 'blog.json'),
+    JSON.stringify(
+      blogData,
+      null,
+      2,
+      'utf8'
+    )
+  );
+  fs.writeFileSync(
+    path.join(mdDataPath, 'docs.json'),
+    JSON.stringify(
+      docsData,
+      null,
+      2,
+      'utf8'
+    )
+  );
+};
+
+module.exports = generateJSONFile;

--- a/tools/docsite/start.js
+++ b/tools/docsite/start.js
@@ -1,0 +1,85 @@
+'use strict';
+
+// Provide custom regenerator runtime and core-js
+require('@babel/polyfill');
+
+// Javascript required hook
+require('@babel/register')({
+  extensions: ['.es6', '.es', '.jsx', '.js'],
+  cache: true,
+});
+
+// Css required hook
+require('css-modules-require-hook')({
+  extensions: ['.scss', '.css'],
+  preprocessCss: (data, filename) =>
+    require('node-sass').renderSync({
+      data,
+      file: filename,
+    }).css,
+  camelCase: true,
+  generateScopedName: '[name]__[local]__[hash:base64:8]',
+});
+
+// Image required hook
+require('asset-require-hook')({
+  extensions: ['jpeg', 'jpg', 'png', 'gif', 'webp'],
+  limit: 8000,
+});
+
+const shell = require('shelljs');
+// const chokidar = require('chokidar');
+const path = require('path');
+const cp = require('child_process');
+// 模拟浏览器环境
+const jsdom = require('jsdom');
+
+const { JSDOM } = jsdom;
+// const dom = new JSDOM(
+//   '<!doctype html><html><body><head><link/><style></style><script></script></head><script></script></body></html>'
+// );
+const dom = new JSDOM(`<!doctype html><html><body><head><link/><style></style><script></script></head><script></script></body></html>`, {
+  url: "http://localhost"
+});
+const { window } = dom;
+const copyProps = (src, target) => {
+  const props = Object.getOwnPropertyNames(src)
+    .filter(prop => typeof target[prop] === 'undefined')
+    .map(prop => Object.getOwnPropertyDescriptor(src, prop));
+  Object.defineProperties(target, props);
+};
+window.requestAnimationFrame = (window.requestAnimationFrame) || (f => window.setTimeout(f, 1e3 / 60));
+window.matchMedia = window.matchMedia || function() {
+  return {
+    matches: false,
+    addListener() {},
+    removeListener() {},
+  };
+};
+global.window = window;
+global.document = window.document;
+global.HTMLElement = window.HTMLElement;
+global.navigator = {
+  userAgent: 'node.js',
+};
+copyProps(window, global);
+
+const generateJSONFile = require('./generateJSONFile.js');
+const generateHTMLFile = require('./generateHTMLFile.js');
+
+const CWD = process.cwd();
+
+const start = () => {
+  shell.cd(CWD);
+  generateJSONFile('dev', CWD);
+  generateHTMLFile('dev', CWD);
+  cp.fork(path.join(__dirname, './watch.js'));
+  const platform = process.platform;
+  if (platform === 'win32') {
+    shell.exec(`node ${['node_modules', 'gulp', 'bin', 'gulp.js'].join(path.sep)}`);
+  } else {
+    shell.exec(`${['node_modules', 'gulp', 'bin', 'gulp.js'].join(path.sep)}`);
+  }
+};
+
+module.exports = start;


### PR DESCRIPTION
# 说明
使用一些hard code的方式去修复build过程的报错问题。

# 已知的问题
目前存在已知的问题如下：
1. 编译的时候会出现:
`err: TypeError: adapter is not a function
    at dispatchRequest (/Users/gming001/Code/wuhan2020/wuhan2020.github.io/node_modules/gitalk/dist/webpack:/node_modules/axios/lib/core/dispatchRequest.js:52:1)
    at process._tickCallback (internal/process/next_tick.js:68:7)
    at Function.Module.runMain (internal/modules/cjs/loader.js:834:11)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)`
2. 国际化存在问题，除了中文和英文，其他的语言版本似乎无法生成

# BreakChange
deploy的时候使用yarn而不是npm。